### PR TITLE
typo の修正

### DIFF
--- a/LICENSE_ja-JP.md
+++ b/LICENSE_ja-JP.md
@@ -4,7 +4,7 @@
 
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>
 
-**本リポジトリ（[Qithub/scripts](https://github.com/Qithub-BOT/scripts/)）と本リポジトリに含まれるすべてのファイル**は「 <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示 - 継承 4.0 国際」 ライセンス</a>の下に提供されています。
+**本リポジトリ（[Qithub-BOT/scripts](https://github.com/Qithub-BOT/scripts/)）と本リポジトリに含まれるすべてのファイル**は「 <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示 - 継承 4.0 国際」 ライセンス</a>の下に提供されています。
 
 これらのファイルに対する、あなたの権利やライセンスの要約は「[コモンズ証](https://creativecommons.org/licenses/by-sa/4.0/deed.ja)」を参照してください。また、法的な詳細については、[リーガルコード](https://creativecommons.org/licenses/by-sa/4.0/legalcode.ja)を参照してください。
 


### PR DESCRIPTION
- 本リポジトリが「Qithub/scripts」になっていたのを「Qithub-BOT/scripts」に修正。

## 対象トピック番号

#30 、 #31