### PR TITLE
dice-roll plugin 元々の意図

### DIFF
--- a/index.php
+++ b/index.php
@@ -434,7 +434,7 @@ if (IS_PROC_REGULAR) {
         //   '&max='       ：サイコロの最大出目
         //   '&dicecode='  ：ダイスコード
         //   '&mode=debug' ：デバッグモード（詳細表示）
-       case 'dice-roll':
+        case 'dice-roll':
             // Number of fling（サイコロを振る回数）
             $times = '1';
             if (isset($_GET['times']) && is_numeric($_GET['times']) && ! empty($_GET['times'])) {

--- a/index.php
+++ b/index.php
@@ -432,8 +432,9 @@ if (IS_PROC_REGULAR) {
         // クエリの引数オプション
         //   '&times='     ：振る回数
         //   '&max='       ：サイコロの最大出目
+        //   '&dicecode='  ：ダイスコード
         //   '&mode=debug' ：デバッグモード（詳細表示）
-        case 'dice-roll':
+       case 'dice-roll':
             // Number of fling（サイコロを振る回数）
             $times = '1';
             if (isset($_GET['times']) && is_numeric($_GET['times']) && ! empty($_GET['times'])) {
@@ -445,7 +446,7 @@ if (IS_PROC_REGULAR) {
                 $max_side = intval($_GET['max']);
             }
             // Set 'dicecode'
-            $dicecode = "${times}d${max_side}";
+            $dicecode = isset($_GET['dicecode']) ? $_GET['dicecode'] : "${times}d${max_side}";
             // Set parameters for Qithub API
             $params = [
                 'is_mode_debug' => IS_MODE_DEBUG,


### PR DESCRIPTION
元々の意図は、`?process=dice-roll&dicecode=2d6` でした。

ダイスコードが一般的でないのは承知の上です。トゥートをトリガーとした時、

```
#dice-roll 2d6
```

とかで呼び出せるとシンプルかつ TRPG ユーザ受けしそうと思っていました。

## 対象トピック番号

#38 , Qithub-BOT/items#14

## 補足

`&times=n&max=m` のインタフェースも残しています。

## TL;DR（進捗・結論 2017/11/05 現在）

- 審議中 ( ´・ω) (´・ω・) (・ω・｀) (ω・｀ )