### PR TITLE
PR #38 “Dice Roll” プラグインの出力を拡張（文字列→配列渡し）

### DIFF
--- a/index.php
+++ b/index.php
@@ -457,7 +457,9 @@ if (IS_PROC_REGULAR) {
 
             // Display result
             if (isset($result['result']) && 'OK' == $result['result']) {
-                echo esc_html($result['value']);
+                $roll = implode(' ', $result['value']['roll']);
+                $sum  = $result['value']['sum'];
+                echo esc_html("Result: ${roll} Sum: ${sum}");
             }
 
             if (IS_MODE_DEBUG) {

--- a/plugins/dice-roll/functions.php.inc
+++ b/plugins/dice-roll/functions.php.inc
@@ -52,16 +52,22 @@ function set_utf8_ja($timezone = 'Asia/Tokyo')
  */
 function dice_roll($dice_code)
 {
-    $param  = explode("D", strtoupper(trim($dice_code)));
-    $sum    = 0;
-    $result = array();
-    $times  = intval($param[0]);
-    $max    = intval($param[1]);
+    $param = explode('D', strtoupper(trim($dice_code)));
+    $sum   = 0;
+    $roll  = array();
+    $times = intval($param[0]);
+    $max   = intval($param[1]);
 
     for ($i = 0; $i < $times; $i++) {
-        $result[] = rand(1, $max);
-        $sum += end($result);
+        $roll[] = rand(1, $max);
+        $sum += end($roll);
     }
 
-    return "Result: ".implode(" ", $result)."\nSum: ".$sum;
+    // $roll = implode(" ", $roll);
+    $result = [
+        'roll' => $roll,
+        'sum'  => $sum,
+    ];
+
+    return $result;
 }


### PR DESCRIPTION
PR #38 の “Dice Roll” プラグインの処理結果を、処理しやすいように結果のみ配列で返し、”Result: x Sum: y”の表示は受け手（index.php）側で処理するようにした。

フォーマットは以下の通り。（’roll’キーが振った結果,’sum’キーが出目の合計）

```
[
    ‘result’ => ‘OK’,
    ‘value’ => [
        ‘roll’ => [x,y,z,,,n],
        ‘sum’ => xx,
    ],
]
```
